### PR TITLE
Always look into package.json for node version

### DIFF
--- a/common/node/lib_node.sh
+++ b/common/node/lib_node.sh
@@ -3,13 +3,9 @@ generate_node_version() {
 }
 
 load_node_config() {
-  if [ -f .node_version ]; then
+  if [ -f package.json ]; then
+    cat package.json | $WARP_HOME/common/json.sh | grep '\["engines","node"\]' | awk '{print $2}' | perl -pe 's/"//g' > .node_version
     LOCAL_NODE_VERSION=`cat .node_version`
-  else
-    if [ -f package.json ]; then
-      cat package.json | $WARP_HOME/common/json.sh | grep '\["engines","node"\]' | awk '{print $2}' | perl -pe 's/"//g' > .node_version
-      LOCAL_NODE_VERSION=`cat .node_version`
-    fi
   fi
   if [ -f npm-shrinkwrap.json ]; then
     LOCAL_NPM_MODULES_HASH=`cat npm-shrinkwrap.json | md5sum | awk '{print $1}'`


### PR DESCRIPTION
Why ask maintainers to duplicate information found into package.json
into a .node_version file?

If you have a nodejs project, you have a package.json file.

Linked with https://github.com/bpaquet/warp/issues/4

thank you
