### PR TITLE
Take npm-shrinkwrap.json into account when present

### DIFF
--- a/packager/node/warp_npm_modules.sh
+++ b/packager/node/warp_npm_modules.sh
@@ -26,13 +26,21 @@ echo "Packaging npm modules to $TARGET_NAME"
 echo "System dependencies : $SYS_DEPENDENCIES"
 
 TMPDIR=$(tmpdir)
-run cp .node_version package.json $TMPDIR
+
+node_files=".node_version package.json"
+
+if [ -e "npm-shrinkwrap.json" ]
+then
+  node_files="$node_files npm-shrinkwrap.json"
+fi
+
+run cp $node_files $TMPDIR
 
 secure_cd $TMPDIR
 
 nvm_command "nvm use v`cat .node_version` && npm install --production"
 
-run rm .node_version package.json
+run rm $node_files
 
 automatic_update_sys_dependencies $TMPDIR
 


### PR DESCRIPTION
Move the file npm-shrinkwrap.json in the tmp folder.

When the warp archive is created for a node env,
the npm-shrinkwrap.json is used to set the version
numbers of the modules.
